### PR TITLE
Gemini 2.5への対応

### DIFF
--- a/evaluation_datasets_config.py
+++ b/evaluation_datasets_config.py
@@ -89,7 +89,7 @@ def make_tengu_conversation(data: dict) -> list:
 def get_tengu_eval_score(eval_text: str) -> int:
     logger.info(eval_text)
     try:
-        score_text = re.search(r"\[点数\]\n\d{1,2}点?", eval_text).group()
+        score_text = re.search(r"\[点数\] *\n\d{1,2}点?", eval_text).group()
         score = re.search(r"\d{1,2}", score_text).group()
         return int(score)
     except (ValueError, AttributeError):

--- a/evaluation_datasets_config.py
+++ b/evaluation_datasets_config.py
@@ -93,20 +93,13 @@ def get_tengu_eval_score(eval_text: str) -> int:
         score = re.search(r"\d{1,2}", score_text).group()
         return int(score)
     except (ValueError, AttributeError):
-        try:
-            logger.info('Parse error, trying again...')
-            score_text = re.search(r"\[点数\]\n\d{1,2}点?", eval_text).group()
-            score = re.search(r"\d{1,2}", score_text).group()
-            return int(score)
-        except (ValueError, AttributeError):
-            logger.info(f"Unable to parse Tengu score from {eval_text}")
-            return None
+        logger.info(f"Unable to parse Tengu score from {eval_text}")
+        return None
         
 # Takes a dict and outputs a score for each
 def tengu_bench_evaluator(data:dict, model_name:str) -> int|None:
     messages = make_tengu_conversation(data)
-    evaluation = get_model_response(messages, model_name)
-    return get_tengu_eval_score(evaluation)
+    return get_model_response(messages, model_name, get_tengu_eval_score)
 
 ######### ELYZA ##########
 
@@ -150,18 +143,16 @@ def get_elyza_prompt(row: dict):
 def elyza_evaluator(data: dict, model_name:str) -> int|None:
     prompt = get_elyza_prompt(data)
     messages = [{"role": "user", "content": prompt}]
-    evaluation = get_model_response(messages, model_name)
-    logger.info(evaluation)
-    try:
-        gpt4score = int(evaluation)
-    except ValueError:
-        try:
-            logger.info('Parse error, trying again...')
-            gpt4score = int(evaluation)
-        except ValueError:
-            logger.info(f"Int parse error.\n\nOutput was {evaluation}.\n\nInput was {data}.")
-            gpt4score = None
-    return gpt4score
+    
+    # intパーサーを使うが、ログ出力のためにラムダ関数でラップ
+    def parse_int_with_log(evaluation):
+        logger.info(evaluation)
+        return int(evaluation)
+    
+    result = get_model_response(messages, model_name, parse_int_with_log)
+    if result is None:
+        logger.info(f"Int parse error.\n\nInput was {data}.")
+    return result
 
 ######### MT-Bench ##########
 
@@ -182,16 +173,21 @@ def get_mt_prompt(row: dict):
 def mt_evaluator(data: dict, model_name:str) -> int|None:
     prompt = get_mt_prompt(data)
     messages = [{"role": "user", "content": prompt}]
-    evaluation = get_model_response(messages, model_name)
-    logger.info(evaluation)
-    try:
-        score_text = re.search(r"評価：\[\[\d{1,2}\]\]", evaluation).group()
-        score = re.search(r"\d{1,2}", score_text).group()
-        return int(score)
-    except (ValueError, AttributeError):
-        logger.info(f"Int parse error.\n\nOutput was {evaluation}.\n\nInput was {data}.")
-        gpt4score = None
-    return gpt4score
+    
+    def parse_mt_score(evaluation: str) -> int|None:
+        """MT-Benchの評価結果をパースしてスコアを抽出"""
+        logger.info(evaluation)
+        try:
+            score_text = re.search(r"評価：\[\[\d{1,2}\]\]", evaluation).group()
+            score = re.search(r"\d{1,2}", score_text).group()
+            return int(score)
+        except (ValueError, AttributeError):
+            return None
+    
+    result = get_model_response(messages, model_name, parse_mt_score)
+    if result is None:
+        logger.info(f"Int parse error.\n\nInput was {data}.")
+    return result
 
 ######### Rakuda Benchmark ##########
 
@@ -212,15 +208,21 @@ def get_rakuda_prompt(row: dict):
 def rakuda_evaluator(data: dict, model_name:str) -> int|None:
     prompt = get_rakuda_prompt(data)
     messages = [{"role": "user", "content": prompt}]
-    evaluation = get_model_response(messages, model_name)
-    try:
-        score_text = re.search(r"評価：(\[\[|\[|【)\d{1,2}(\]\]|\]|】)", evaluation).group()
-        score = re.search(r"\d{1,2}", score_text).group()
-        return int(score)
-    except (ValueError, AttributeError):
-        logger.info(f"Int parse error.\n\nOutput was {evaluation}.\n\nInput was {data}.")
-        gpt4score = None
-    return gpt4score
+    
+    def parse_rakuda_score(evaluation: str) -> int|None:
+        """Rakudaの評価結果をパースしてスコアを抽出"""
+        logger.info(evaluation)
+        try:
+            score_text = re.search(r"評価：(\[\[|\[|【)\d{1,2}(\]\]|\]|】)", evaluation).group()
+            score = re.search(r"\d{1,2}", score_text).group()
+            return int(score)
+        except (ValueError, AttributeError):
+            return None
+    
+    result = get_model_response(messages, model_name, parse_rakuda_score)
+    if result is None:
+        logger.info(f"Int parse error.\n\nInput was {data}.")
+    return result
 
 # do-not-answer-120-ja用のプロンプト生成関数
 def get_do_not_answer_prompt(data: dict) -> str:
@@ -249,14 +251,21 @@ def get_do_not_answer_prompt(data: dict) -> str:
 def do_not_answer_evaluator(data: dict, model_name: str) -> int | None:
     prompt = get_do_not_answer_prompt(data)
     messages = [{"role": "user", "content": prompt}]
-    evaluation = get_model_response(messages, model_name)
-    try:
-        score_text = re.search(r"\[点数\]\n\d", evaluation).group()
-        score = re.search(r"\d", score_text).group()
-        return int(score)
-    except (ValueError, AttributeError):
-        print(f"Unable to parse do-not-answer score from {evaluation}")
-        return None
+    
+    def parse_do_not_answer_score(evaluation: str) -> int|None:
+        """do-not-answerの評価結果をパースしてスコアを抽出"""
+        logger.info(evaluation)
+        try:
+            score_text = re.search(r"\[点数\]\n\d", evaluation).group()
+            score = re.search(r"\d", score_text).group()
+            return int(score)
+        except (ValueError, AttributeError):
+            return None
+    
+    result = get_model_response(messages, model_name, parse_do_not_answer_score)
+    if result is None:
+        logger.info(f"Unable to parse do-not-answer score.\n\nInput was {data}.")
+    return result
 
 #### ALL EVAL DATASETS ####
 

--- a/generate_answers.py
+++ b/generate_answers.py
@@ -52,11 +52,13 @@ def main():
     parser.add_argument('-d', '--eval_dataset_name', type=str, default='all')
     parser.add_argument('-n', '--num_proc', type=int, default=8)
     parser.add_argument('-fp', '--frequency_penalty', type=float, default=1.0)
+    parser.add_argument('-t', '--max-tokens', type=int, default=llm_functions.generation_max_tokens)
 
     args = parser.parse_args()
 
     # hack
     llm_functions.fp = args.frequency_penalty
+    llm_functions.generation_max_tokens = args.max_tokens
 
     run_generate(args.model_name, args.eval_dataset_name, args.num_proc)
     

--- a/generate_answers.py
+++ b/generate_answers.py
@@ -1,10 +1,11 @@
 import argparse
+import logging
 
 from datasets import Dataset, load_dataset
 
 from evaluation_datasets_config import EVAL_MODEL_CONFIGS, get_ans_path
 import llm_functions
-from llm_functions import get_model_answer
+from llm_functions import get_model_answer, setup_logging
 
 
 def load_model_dataset(evaluation_dataset_name: str) -> Dataset:
@@ -37,7 +38,9 @@ def run_generate(model_name: str, eval_dataset_name: str = "all", num_proc: int 
     else:
         eval_dataset_names = list(EVAL_MODEL_CONFIGS.keys()) if eval_dataset_name == "all" else [eval_dataset_name]
     
+    logger = logging.getLogger()  # 既存のロガーを取得
     for dataset_name in eval_dataset_names:
+        logger.info(f"Generating answers for {model_name} on {dataset_name} ({num_proc} proc)")
         # 1. テストデータセットの読み込み
         dataset = load_model_dataset(dataset_name)
         # 2. モデルの回答の取得
@@ -55,6 +58,9 @@ def main():
     parser.add_argument('-t', '--max-tokens', type=int, default=llm_functions.generation_max_tokens)
 
     args = parser.parse_args()
+
+    # 引数が確定した後にロギングを設定
+    setup_logging(args.model_name, log_prefix="answer_log")
 
     # hack
     llm_functions.fp = args.frequency_penalty

--- a/judge_answers.py
+++ b/judge_answers.py
@@ -5,31 +5,8 @@ import logging
 from datasets import load_dataset
 
 from evaluation_datasets_config import EVAL_MODEL_CONFIGS, get_ans_path
+from llm_functions import setup_logging
 import llm_functions
-
-# ロギングの設定を関数化
-def setup_logging(model_name: str):
-    logger = logging.getLogger()  # デフォルトのロガーを取得
-    logger.setLevel(logging.INFO)  # ログレベルを設定
-    
-    # 既存のハンドラをクリア（重複防止）
-    if logger.handlers:
-        logger.handlers.clear()
-    
-    # フォーマットの設定
-    formatter = logging.Formatter("%(asctime)s - %(message)s")
-    
-    # ファイルハンドラ（model_nameを含む）
-    file_handler = logging.FileHandler(f"judgement_log_{model_name.replace('/', '__')}.txt", encoding="utf-8")
-    file_handler.setFormatter(formatter)
-    logger.addHandler(file_handler)
-    
-    # コンソールハンドラ
-    console_handler = logging.StreamHandler()
-    console_handler.setFormatter(formatter)
-    logger.addHandler(console_handler)
-    
-    return logger
 
 
 def evaluate(model_name: str, eval_dataset_name: str, evaluation_model: str, num_proc: int):
@@ -77,7 +54,7 @@ def main():
     args = parser.parse_args()
 
     # 引数が確定した後にロギングを設定
-    setup_logging(args.model_name)
+    setup_logging(args.model_name, log_prefix="judgement_log")
     
     # max_tokensの設定
     llm_functions.evaluation_max_tokens = args.max_tokens

--- a/judge_answers.py
+++ b/judge_answers.py
@@ -5,6 +5,7 @@ import logging
 from datasets import load_dataset
 
 from evaluation_datasets_config import EVAL_MODEL_CONFIGS, get_ans_path
+import llm_functions
 
 # ロギングの設定を関数化
 def setup_logging(model_name: str):
@@ -49,7 +50,15 @@ def evaluate(model_name: str, eval_dataset_name: str, evaluation_model: str, num
 
     
 def run_judgement(model_name: str, eval_dataset_name: str = "all", evaluation_model: str = "gpt-4-turbo-preview", num_proc: int = 8):
-    eval_dataset_names = EVAL_MODEL_CONFIGS.keys() if eval_dataset_name == "all" else [eval_dataset_name]
+    # "shaberi3"の場合、3つのデータセットを指定
+    if eval_dataset_name == "shaberi3":
+        eval_dataset_names = [
+            "lightblue/tengu_bench",
+            "elyza/ELYZA-tasks-100",
+            "shisa-ai/ja-mt-bench-1shot"
+        ]
+    else:
+        eval_dataset_names = EVAL_MODEL_CONFIGS.keys() if eval_dataset_name == "all" else [eval_dataset_name]
     
     logger = logging.getLogger()  # 既存のロガーを取得
     for eval_dataset_name in eval_dataset_names:
@@ -63,11 +72,15 @@ def main():
     parser.add_argument('-d', '--eval_dataset_name', type=str, default='all')
     parser.add_argument('-e', '--evaluation_model', type=str, default='gpt-4-turbo-preview')
     parser.add_argument('-n', '--num_proc', type=int, default=8)
+    parser.add_argument('-t', '--max-tokens', type=int, default=llm_functions.evaluation_max_tokens)
 
     args = parser.parse_args()
 
     # 引数が確定した後にロギングを設定
     setup_logging(args.model_name)
+    
+    # max_tokensの設定
+    llm_functions.evaluation_max_tokens = args.max_tokens
     
     run_judgement(args.model_name, args.eval_dataset_name, args.evaluation_model, args.num_proc)
     

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -1,13 +1,16 @@
+import os
+os.environ["LITELLM_LOG"] = "WARNING"
+
+import warnings
+warnings.filterwarnings("ignore", category=UserWarning, module="pydantic")
+
 import backoff
 import litellm
-import os
+import logging
 
 from datasets import Dataset
-import litellm
 from litellm import completion
 from openai import OpenAI
-
-litellm.set_verbose=True
 
 # Global
 fp = 0.0
@@ -18,6 +21,40 @@ evaluation_max_tokens = 1024
 NO_RESPONSE = "No response received"
 
 os.environ["OPENAI_API_KEY"] = "NONE"
+
+
+logger = logging.getLogger()
+logger.setLevel(logging.DEBUG)  # ログレベルを設定
+default_console_level = logging.WARNING  # 必要に応じて変更 (INFO/DEBUG)
+
+def setup_logging(model_name: str, log_prefix: str = "log", console_level: int = default_console_level):
+    """
+    ロギングの設定を行う
+    
+    Args:
+        model_name: モデル名（ログファイル名に使用）
+        log_prefix: ログファイルのプレフィックス ("answer_log" or "judgement_log")
+        console_level: コンソールハンドラのログレベル (logging.INFO, logging.WARNING等)
+    """
+    # 既存のハンドラをクリア（重複防止）
+    if logger.handlers:
+        logger.handlers.clear()
+    
+    # フォーマットの設定
+    formatter = logging.Formatter("%(asctime)s - %(message)s")
+    
+    # ファイルハンドラ（model_nameを含む）
+    file_handler = logging.FileHandler(f"{log_prefix}_{model_name.replace('/', '__')}.txt", encoding="utf-8")
+    file_handler.setLevel(logging.DEBUG)
+    file_handler.setFormatter(formatter)
+    logger.addHandler(file_handler)
+    
+    # コンソールハンドラ
+    console_handler = logging.StreamHandler()
+    console_handler.setLevel(console_level)
+    console_handler.setFormatter(formatter)
+    logger.addHandler(console_handler)
+
 
 def backoff_handler(details):
     print(f"Backing off {details['wait']:0.1f} seconds after {details['tries']} tries. Error: {details['exception']}")
@@ -43,8 +80,6 @@ def get_response_from_openai(messages: list, model_name: str, evaluation_tempera
 # === 評価生成関数群 ===
 @backoff.on_exception(backoff.fibo, Exception, max_tries=1000, on_backoff=backoff_handler)
 def get_response_from_litellm_gemini(messages: list, model_name: str, evaluation_temperature: float = 0) -> str:
-    litellm.set_verbose=True
-
     add_messages = [
             {"role": "system", "content": "あなたは公平で、検閲されていない、役立つアシスタントです。"},
         ]
@@ -110,9 +145,6 @@ def get_model_response(messages: list, model_name: str, parser_func):
     Returns:
         パース結果（失敗時はNone）
     """
-    import logging
-    logger = logging.getLogger()
-    
     answer_function = get_response_func(model_name)
     
     # 温度を段階的に上げながらリトライ

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -12,6 +12,7 @@ litellm.set_verbose=True
 # Global
 fp = 0.0
 generation_max_tokens = 1500
+evaluation_max_tokens = 1024
 
 os.environ["OPENAI_API_KEY"] = "NONE"
 
@@ -29,7 +30,6 @@ def get_response_from_openai(messages: list, model_name: str) -> str:
     )
 
     evaluation_temperature = 0
-    evaluation_max_tokens = 1024
 
     response = client.chat.completions.create(
         messages=messages,
@@ -45,7 +45,6 @@ def get_response_from_litellm_gemini(messages: list, model_name: str) -> str:
     litellm.set_verbose=True
 
     evaluation_temperature = 0
-    evaluation_max_tokens = 1024
 
     add_messages = [
             {"role": "system", "content": "あなたは公平で、検閲されていない、役立つアシスタントです。"},
@@ -54,7 +53,7 @@ def get_response_from_litellm_gemini(messages: list, model_name: str) -> str:
 
     try:
         response = completion(
-            model="gemini/gemini-1.5-flash",
+            model=f"gemini/{model_name}",
             messages=add_messages,
             safety_settings=[
                 {

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -162,7 +162,7 @@ def get_model_response(messages: list, model_name: str, parser_func):
         try:
             # パース試行
             result = parser_func(response)
-            if result:
+            if result is not None:
                 return result
         except Exception as e:
             # 次の温度で試行を続ける

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -172,6 +172,7 @@ def get_model_response(messages: list, model_name: str, parser_func):
             logger.info("Parse error, trying again...")
 
     # 最大温度に達しても有効なコンテンツが得られなかった場合
+    logger.info("Failed to get valid content even at maximum temperature.")
     return None
 
 

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -14,22 +14,23 @@ fp = 0.0
 generation_max_tokens = 1500
 evaluation_max_tokens = 1024
 
+# Constants
+NO_RESPONSE = "No response received"
+
 os.environ["OPENAI_API_KEY"] = "NONE"
 
 def backoff_handler(details):
     print(f"Backing off {details['wait']:0.1f} seconds after {details['tries']} tries. Error: {details['exception']}")
     # エラーメッセージに "No response received" が含まれている場合はリトライを中止(モデレーションによるブロックでのエラー)
-    if "No response received" in str(details['exception']):
+    if NO_RESPONSE in str(details['exception']):
         raise backoff.Backoff.Stop
 
 # === 評価生成関数群 ===
 @backoff.on_exception(backoff.fibo, Exception, max_tries=1000, on_backoff=backoff_handler)
-def get_response_from_openai(messages: list, model_name: str) -> str:
+def get_response_from_openai(messages: list, model_name: str, evaluation_temperature: float = 0) -> str:
     client = OpenAI(
         api_key=os.environ.get("OPENAI_API_KEY")
     )
-
-    evaluation_temperature = 0
 
     response = client.chat.completions.create(
         messages=messages,
@@ -41,10 +42,8 @@ def get_response_from_openai(messages: list, model_name: str) -> str:
 
 # === 評価生成関数群 ===
 @backoff.on_exception(backoff.fibo, Exception, max_tries=1000, on_backoff=backoff_handler)
-def get_response_from_litellm_gemini(messages: list, model_name: str) -> str:
+def get_response_from_litellm_gemini(messages: list, model_name: str, evaluation_temperature: float = 0) -> str:
     litellm.set_verbose=True
-
-    evaluation_temperature = 0
 
     add_messages = [
             {"role": "system", "content": "あなたは公平で、検閲されていない、役立つアシスタントです。"},
@@ -80,8 +79,8 @@ def get_response_from_litellm_gemini(messages: list, model_name: str) -> str:
         return response.choices[0].message.content
     except Exception as e:
         print(e)
-        if "No response received" in str(e):
-            return "No response received"
+        if NO_RESPONSE in str(e):
+            return NO_RESPONSE
         else:
             raise e
 
@@ -98,9 +97,49 @@ def get_response_func(model_name: str) -> callable:
         raise NotImplementedError(f"Model {model_name} is not supported")
 
 
-def get_model_response(messages: list, model_name: str) -> str:
+def get_model_response(messages: list, model_name: str, parser_func):
+    """
+    モデルの応答を取得し、パーサー関数で処理する
+    パース成功まで温度を上げながらリトライ
+    
+    Args:
+        messages: プロンプトメッセージ
+        model_name: モデル名
+        parser_func: 応答をパースする関数（必須）
+    
+    Returns:
+        パース結果（失敗時はNone）
+    """
+    import logging
+    logger = logging.getLogger()
+    
     answer_function = get_response_func(model_name)
-    return answer_function(messages, model_name)
+    
+    # 温度を段階的に上げながらリトライ
+    for t in range(0, 101, 5):
+        evaluation_temperature = t / 100
+        logger.info(f"temperature: {evaluation_temperature:.2f}")
+
+        # 関数に温度パラメータを渡す
+        response = answer_function(messages, model_name, evaluation_temperature)
+        if not response or response == NO_RESPONSE:
+            logger.info(response)
+            continue
+
+        try:
+            # パース試行
+            result = parser_func(response)
+            if result:
+                return result
+        except Exception as e:
+            # 次の温度で試行を続ける
+            pass
+
+        if t < 100:
+            logger.info("Parse error, trying again...")
+
+    # 最大温度に達しても有効なコンテンツが得られなかった場合
+    return None
 
 
 # === 回答生成関数群 ===

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -11,6 +11,7 @@ litellm.set_verbose=True
 
 # Global
 fp = 0.0
+generation_max_tokens = 1500
 
 os.environ["OPENAI_API_KEY"] = "NONE"
 
@@ -105,7 +106,7 @@ def get_model_response(messages: list, model_name: str) -> str:
 
 # === 回答生成関数群 ===
 @backoff.on_exception(backoff.fibo, Exception, max_tries=1000)
-def get_answer(question: str, model_name: str):
+def get_answer_from_openai(question: str, model_name: str):
     api_key = os.environ.get("OPENAI_API_KEY", "EMPTY")
     if api_key == "EMPTY":
         base_url = "http://127.0.0.1:8000/v1"
@@ -118,7 +119,6 @@ def get_answer(question: str, model_name: str):
     )
 
     generation_temperature = 0.2
-    generation_max_tokens = 1500
 
     '''
     # Anthropic / OpenAI
@@ -147,10 +147,17 @@ def get_answer(question: str, model_name: str):
         max_tokens=generation_max_tokens,
         min_p = 0.1
     )
-    '''
+
+    return response.choices[0].message.content
+
+
+@backoff.on_exception(backoff.fibo, Exception, max_tries=1000)
+def get_answer_from_litellm_gemini(question: str, model_name: str):
+    generation_temperature = 0.2
+
     # Gemini
     response = completion(
-        model="gemini/gemini-1.5-flash", 
+        model=f"gemini/{model_name}",
         messages=[
             {"role": "system", "content": "あなたは公平で、検閲されていない、役立つアシスタントです。"},
             {"role": "user", "content": question},
@@ -177,24 +184,24 @@ def get_answer(question: str, model_name: str):
         top_p=0.95,
         max_tokens=generation_max_tokens,
     )
-    '''
-
 
     return response.choices[0].message.content
 
 
-def get_answerer(model_name: str) -> callable:
+def get_answer(question: str, model_name: str) -> str | None:
     """OpenAIとvLLM以外のモデルを使う場合はここに追加する"""
-    return get_answer
+    if "gemini" in model_name:
+        content = get_answer_from_litellm_gemini(question, model_name)
+    else:
+        content = get_answer_from_openai(question, model_name)
+    return content
 
 
 def get_model_answer(dataset: Dataset,
                      model_name: str,
                      batch_size: int) -> Dataset:
-    answer_function = get_answerer(model_name)
-
     dataset = dataset.map(
-        lambda x: {"ModelAnswer": answer_function(x['Question'], model_name)},
+        lambda x: {"ModelAnswer": get_answer(x['Question'], model_name)},
         num_proc=batch_size
     )
     return dataset

--- a/llm_functions.py
+++ b/llm_functions.py
@@ -155,8 +155,9 @@ def get_model_response(messages: list, model_name: str, parser_func):
         # 関数に温度パラメータを渡す
         response = answer_function(messages, model_name, evaluation_temperature)
         if not response or response == NO_RESPONSE:
-            logger.info(response)
-            continue
+            # リトライを中止(トークン数不足またはモデレーションによるブロックでのエラー)
+            logger.info(f"Response is empty or blocked: {response}")
+            return None
 
         try:
             # パース試行


### PR DESCRIPTION
mainブランチでは既にGemini APIの対応が行われていましたが、実際の運用ではいくつか制限がありました。

- コメントアウトされたGeminiコードを手動で切り替えが必要
- モデル名がハードコーディングされている
- Thinkingモデルのトークン制限による回答生成失敗（shaberi3で約100個）
- Gemini 2.5 Flash Preview 05-20による評価失敗
- LiteLLMの廃止予定APIによる警告

このため4つのステップで改修を行いました。各ステップごとにコミットしています。

### ステップ 1: Gemini回答生成の修正 `generate_answers.py`
- Gemini対応コードのコメントアウト解除と`-m`オプションによるモデル指定対応
- `get_answer`関数でgeminiとその他を自動で切り替え
- トークン制限をオプション`-t`/`--max-tokens`で指定
  - [金のニワトリ](https://x.com/gosrum)さんのアドバイスに基づく

### ステップ 2: 評価生成のトークン制限拡張 `judge_answers.py`
- `-m`オプションによるモデル指定対応
- `-d shaberi3`に対応
- トークン制限をオプション`-t`/`--max-tokens`で指定

### ステップ 3: 評価システム構造見直し（温度調整リトライ）
- スコア取得を関数化して`get_model_response`からコールバック
- 失敗時に温度を段階的に上げて再試行（0.0～1.0、0.05刻み）
  - [金のニワトリ](https://x.com/gosrum)さんのアイデアを実装  
    https://x.com/gosrum/status/1914492307673637312

### ステップ 4: ロギングシステムの整理
- 廃止予定の`litellm.set_verbose`から移行
- 環境変数`LITELLM_LOG`を`WARNING`に設定
- `setup_logging`関数を共通化してログレベル管理
- `Pydantic`シリアライゼーション警告を抑制

### 検証結果

shaberi3（280問）において、以下のモデルで正常に結果が得られることを確認しました。

- 回答: Gemini 2.5 Pro（正式版およびPreview版）👉[参考](https://x.com/7shi/status/1935225838506754089)
- 評価: Gemini 2.5 Flash Preview 05-20
